### PR TITLE
feat: correct money conversion, add tests and static analysis config

### DIFF
--- a/Model/Convert/CartItemToLineItem.php
+++ b/Model/Convert/CartItemToLineItem.php
@@ -46,11 +46,13 @@ class CartItemToLineItem
         $total = $cartItem->getRowTotalInclTax();
         $tax = $cartItem->getTaxAmount();
 
-        $lineItem->setBaseAmount($this->convertPrice->execute($baseAmount));
-        $lineItem->setSubtotal($this->convertPrice->execute($subtotal));
-        $lineItem->setDiscount($this->convertPrice->execute($discount));
-        $lineItem->setTotal($this->convertPrice->execute($total));
-        $lineItem->setTax($this->convertPrice->execute($tax));
+        $currencyCode = $cartItem->getQuote()->getCurrency()?->getStoreCurrencyCode() ?? 'USD';
+
+        $lineItem->setBaseAmount($this->convertPrice->execute($baseAmount, $currencyCode));
+        $lineItem->setSubtotal($this->convertPrice->execute($subtotal, $currencyCode));
+        $lineItem->setDiscount($this->convertPrice->execute($discount, $currencyCode));
+        $lineItem->setTotal($this->convertPrice->execute($total, $currencyCode));
+        $lineItem->setTax($this->convertPrice->execute($tax, $currencyCode));
         $lineItem->setItem($item);
 
         return $lineItem;

--- a/Model/Convert/CartToFulfillmentAddress.php
+++ b/Model/Convert/CartToFulfillmentAddress.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Magebit\AgenticCommerce\Model\Convert;
 
 use Magebit\AgenticCommerce\Api\Data\AddressInterface;
@@ -25,6 +27,8 @@ class CartToFulfillmentAddress
     }
 
     /**
+     * Builds the optional ACP fulfillment_address, or null when the quote has no usable address yet.
+     *
      * @param Quote $cart
      * @return AddressInterface|null
      */
@@ -32,32 +36,55 @@ class CartToFulfillmentAddress
     {
         $shippingAddress = $cart->getShippingAddress();
 
-        // Check if required address fields are present
-        if (!$shippingAddress->getCity()
-            || !$shippingAddress->getCountry()
-            || !$shippingAddress->getPostcode()
-            || !$shippingAddress->getStreet()
-        ) {
+        $name = trim(
+            $this->toTrimmedString($shippingAddress->getFirstname())
+            . ' '
+            . $this->toTrimmedString($shippingAddress->getLastname())
+        );
+        $street = $this->getStreetLines($shippingAddress->getStreet());
+        $city = $this->toTrimmedString($shippingAddress->getCity());
+        $country = $this->toTrimmedString($shippingAddress->getCountry());
+        $postalCode = $this->toTrimmedString($shippingAddress->getPostcode());
+
+        // Every one of these is non-nullable on AddressInterface, so a quote missing any cannot be represented.
+        if ($name === '' || $street === [] || $city === '' || $country === '' || $postalCode === '') {
             return null;
         }
 
-        $name = trim($shippingAddress->getFirstname() . ' ' . $shippingAddress->getLastname());
-
-        // If name is empty, use a placeholder or return null
-        if (empty($name)) {
-            return null;
-        }
+        // State stays optional: a shipping-estimate quote may carry country and postcode but no region.
+        $state = $this->toTrimmedString($shippingAddress->getRegion());
 
         /** @var AddressInterface $address */
         $address = $this->addressInterfaceFactory->create();
         $address->setName($name);
-        $address->setLineOne($shippingAddress->getStreet()[0]);
-        $address->setLineTwo($shippingAddress->getStreet()[1] ?? null);
-        $address->setCity($shippingAddress->getCity());
-        $address->setState($shippingAddress->getRegion());
-        $address->setCountry($shippingAddress->getCountry());
-        $address->setPostalCode($shippingAddress->getPostcode());
+        $address->setLineOne($street[0]);
+        $address->setLineTwo($street[1] ?? null);
+        $address->setCity($city);
+        $address->setState($state !== '' ? $state : null);
+        $address->setCountry($country);
+        $address->setPostalCode($postalCode);
 
         return $address;
+    }
+
+    /**
+     * @param mixed $street
+     * @return string[]
+     */
+    private function getStreetLines(mixed $street): array
+    {
+        // Quote\Address::getStreet() yields [''] for an unset street, and may hold blank trailing lines.
+        $lines = array_map($this->toTrimmedString(...), is_array($street) ? $street : [$street]);
+
+        return array_values(array_filter($lines, static fn (string $line): bool => $line !== ''));
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    private function toTrimmedString(mixed $value): string
+    {
+        return is_scalar($value) ? trim((string) $value) : '';
     }
 }

--- a/Model/Convert/CartToFulfillmentOptions.php
+++ b/Model/Convert/CartToFulfillmentOptions.php
@@ -40,6 +40,7 @@ class CartToFulfillmentOptions
     {
         $fulfillmentOptions = [];
         $shippingMethods = $this->getShippingMethods($cart);
+        $currencyCode = $cart->getCurrency()?->getStoreCurrencyCode() ?? 'USD';
 
         foreach ($shippingMethods as $shippingMethod) {
             /** @var FulfillmentOptionInterface $fulfillmentOption */
@@ -52,9 +53,9 @@ class CartToFulfillmentOptions
             $priceInclTax = $shippingMethod->getPriceInclTax();
             $tax = $priceInclTax - $priceExclTax;
 
-            $fulfillmentOption->setSubtotal($this->convertPrice->execute($priceExclTax));
-            $fulfillmentOption->setTax($this->convertPrice->execute($tax));
-            $fulfillmentOption->setTotal($this->convertPrice->execute($priceInclTax));
+            $fulfillmentOption->setSubtotal($this->convertPrice->execute($priceExclTax, $currencyCode));
+            $fulfillmentOption->setTax($this->convertPrice->execute($tax, $currencyCode));
+            $fulfillmentOption->setTotal($this->convertPrice->execute($priceInclTax, $currencyCode));
             $fulfillmentOptions[] = $fulfillmentOption;
         }
 

--- a/Model/Convert/CartToTotals.php
+++ b/Model/Convert/CartToTotals.php
@@ -34,6 +34,7 @@ class CartToTotals
     public function execute(Quote $cart): array
     {
         $totals = [];
+        $currencyCode = $cart->getCurrency()?->getStoreCurrencyCode() ?? 'USD';
 
         foreach ($cart->getTotals() as $cartTotal) {
             /** @var TotalInterface $total */
@@ -41,7 +42,7 @@ class CartToTotals
 
             $total->setType($cartTotal->getCode());
             $total->setDisplayText((string) $cartTotal->getTitle());
-            $total->setAmount($this->convertPrice->execute($cartTotal->getValue()));
+            $total->setAmount($this->convertPrice->execute($cartTotal->getValue(), $currencyCode));
             $totals[] = $total;
         }
 

--- a/Model/Convert/ConvertPrice.php
+++ b/Model/Convert/ConvertPrice.php
@@ -8,16 +8,69 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Magebit\AgenticCommerce\Model\Convert;
 
 class ConvertPrice
 {
+    public const DEFAULT_EXPONENT = 2;
+
     /**
-     * @param float $price
+     * ISO 4217 currencies whose minor-unit exponent differs from the default of 2.
+     *
+     * @var array<string, int>
+     */
+    private const EXPONENTS = [
+        'BIF' => 0,
+        'CLP' => 0,
+        'DJF' => 0,
+        'GNF' => 0,
+        'ISK' => 0,
+        'JPY' => 0,
+        'KMF' => 0,
+        'KRW' => 0,
+        'PYG' => 0,
+        'RWF' => 0,
+        'UGX' => 0,
+        'UYI' => 0,
+        'VND' => 0,
+        'VUV' => 0,
+        'XAF' => 0,
+        'XOF' => 0,
+        'XPF' => 0,
+        'BHD' => 3,
+        'IQD' => 3,
+        'JOD' => 3,
+        'KWD' => 3,
+        'LYD' => 3,
+        'OMR' => 3,
+        'TND' => 3,
+    ];
+
+    /**
+     * Convert a major-unit amount to the currency's ISO 4217 minor units.
+     *
+     * @param float $amount
+     * @param string $currencyCode
      * @return int
      */
-    public function execute(float $price): int
+    public function execute(float $amount, string $currencyCode): int
     {
-        return (int) ($price * 100);
+        // Round on the decimal string: 19.99 * 100 is 1998.9999999999998, which (int) truncates to 1998.
+        $decimal = number_format($amount, $this->getExponent($currencyCode), '.', '');
+
+        return (int) str_replace('.', '', $decimal);
+    }
+
+    /**
+     * Number of decimal places the currency's minor unit is expressed in.
+     *
+     * @param string $currencyCode
+     * @return int
+     */
+    public function getExponent(string $currencyCode): int
+    {
+        return self::EXPONENTS[strtoupper($currencyCode)] ?? self::DEFAULT_EXPONENT;
     }
 }

--- a/Observer/SalesOrderCreditmemoRefundObserver.php
+++ b/Observer/SalesOrderCreditmemoRefundObserver.php
@@ -54,10 +54,13 @@ class SalesOrderCreditmemoRefundObserver implements ObserverInterface
             return;
         }
 
+        // Grand total is denominated in the order currency, not the base currency.
+        $currencyCode = (string) ($creditmemo->getOrderCurrencyCode() ?: 'USD');
+
         /** @var RefundInterface $refund */
         $refund = $this->refundInterfaceFactory->create(['data' => [
             'type' => 'original_payment',
-            'amount' => $this->convertPrice->execute($creditmemo->getGrandTotal()),
+            'amount' => $this->convertPrice->execute((float) $creditmemo->getGrandTotal(), $currencyCode),
         ]]);
 
         $webhookEvent = $this->orderToOrderCreatedUpdatedWebhook->execute(

--- a/Test/Unit/CheckoutSessionFixtureTest.php
+++ b/Test/Unit/CheckoutSessionFixtureTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * This file is part of the Magebit_AgenticCommerce package.
+ *
+ * @copyright Copyright (c) 2025 Magebit, Ltd. (https://magebit.com/)
+ * @author    Magebit <info@magebit.com>
+ * @license   MIT
+ */
+
+declare(strict_types=1);
+
+namespace Magebit\AgenticCommerce\Test\Unit;
+
+use JsonException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the golden ACP fixtures. No ACP JSON Schema set is vendored yet, so these pin
+ * structure only; swap in schema assertions once a spec is available.
+ */
+class CheckoutSessionFixtureTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function sessionFixtureProvider(): array
+    {
+        return [
+            'create 200' => ['checkout_session.create.200.json'],
+            'get 200' => ['checkout_session.get.200.json'],
+            'update 200' => ['checkout_session.update.200.json'],
+            'cancel 200' => ['checkout_session.cancel.200.json'],
+        ];
+    }
+
+    /**
+     * @dataProvider sessionFixtureProvider
+     * @param string $fixture
+     * @return void
+     * @throws JsonException
+     */
+    public function testSessionFixtureHasExpectedEnvelope(string $fixture): void
+    {
+        $payload = self::loadFixture($fixture);
+
+        foreach (['id', 'line_items', 'totals', 'currency', 'status', 'links', 'messages'] as $key) {
+            $this->assertArrayHasKey($key, $payload, sprintf('"%s" missing from %s', $key, $fixture));
+        }
+
+        $this->assertSame('checkout_session_placeholder_0001', $payload['id'], 'Session id must stay scrubbed.');
+        $this->assertNotEmpty($payload['line_items']);
+    }
+
+    /**
+     * @dataProvider sessionFixtureProvider
+     * @param string $fixture
+     * @return void
+     * @throws JsonException
+     */
+    public function testSessionFixtureCarriesNoSchemaYet(string $fixture): void
+    {
+        $this->assertNotEmpty(self::loadFixture($fixture));
+        $this->markTestSkipped(
+            'No ACP JSON Schema set is vendored; fixtures are captured for future conformance checks.'
+        );
+    }
+
+    /**
+     * POST /checkout_sessions/{id}/complete returns HTTP 400 for the seeded payment token.
+     *
+     * @return void
+     * @throws JsonException
+     */
+    public function testCompleteResponseRecordsKnownBrokenState(): void
+    {
+        $payload = self::loadFixture('checkout_session.complete.400.BROKEN.json');
+
+        $this->assertSame('invalid_request', $payload['code']);
+        $this->markTestIncomplete(
+            'ACP complete returns 400 "The requested Payment Method is not available." '
+            . 'Fixture records the broken state.'
+        );
+    }
+
+    /**
+     * @param string $name
+     * @return array<mixed>
+     * @throws JsonException
+     */
+    private static function loadFixture(string $name): array
+    {
+        $path = __DIR__ . '/_fixtures/' . $name;
+
+        if (!is_file($path)) {
+            self::markTestSkipped(sprintf('Fixture "%s" is missing.', $name));
+        }
+
+        /** @var array<mixed> $decoded */
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+}

--- a/Test/Unit/Model/Convert/CartToFulfillmentAddressTest.php
+++ b/Test/Unit/Model/Convert/CartToFulfillmentAddressTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * This file is part of the Magebit_AgenticCommerce package.
+ *
+ * @copyright Copyright (c) 2025 Magebit, Ltd. (https://magebit.com/)
+ * @author    Magebit <info@magebit.com>
+ * @license   MIT
+ */
+
+declare(strict_types=1);
+
+namespace Magebit\AgenticCommerce\Test\Unit\Model\Convert;
+
+use Magebit\AgenticCommerce\Api\Data\AddressInterfaceFactory;
+use Magebit\AgenticCommerce\Model\Convert\CartToFulfillmentAddress;
+use Magebit\AgenticCommerce\Model\Data\Address;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address as QuoteAddress;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CartToFulfillmentAddressTest extends TestCase
+{
+    /**
+     * @var AddressInterfaceFactory&MockObject
+     */
+    private AddressInterfaceFactory $addressFactory;
+
+    /**
+     * @var CartToFulfillmentAddress
+     */
+    private CartToFulfillmentAddress $cartToFulfillmentAddress;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->addressFactory = $this->getMockBuilder(AddressInterfaceFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
+            ->getMock();
+        $this->addressFactory->method('create')->willReturnCallback(static fn (): Address => new Address());
+
+        $this->cartToFulfillmentAddress = new CartToFulfillmentAddress($this->addressFactory);
+    }
+
+    /**
+     * An address the buyer never supplied must be omitted, not emitted as an object full of nulls.
+     *
+     * @return void
+     */
+    public function testEmptyQuoteAddressYieldsNull(): void
+    {
+        $cart = $this->createCart([]);
+
+        $this->assertNull($this->cartToFulfillmentAddress->execute($cart));
+    }
+
+    /**
+     * A shipping-estimate quote carries country and postcode only; that must not fatal.
+     *
+     * @dataProvider partialAddressProvider
+     * @param array<string, mixed> $data
+     * @return void
+     */
+    public function testPartialAddressYieldsNull(array $data): void
+    {
+        $cart = $this->createCart($data);
+
+        $this->assertNull($this->cartToFulfillmentAddress->execute($cart));
+    }
+
+    /**
+     * @return array<string, array{0: array<string, mixed>}>
+     */
+    public static function partialAddressProvider(): array
+    {
+        $complete = [
+            'firstname' => 'Ada',
+            'lastname' => 'Lovelace',
+            'street' => ['123 Main St'],
+            'city' => 'Austin',
+            'country' => 'US',
+            'postcode' => '78701',
+        ];
+
+        return [
+            'country and postcode only' => [['country' => 'US', 'postcode' => '78701']],
+            'no name' => [array_merge($complete, ['firstname' => null, 'lastname' => null])],
+            'no street' => [array_merge($complete, ['street' => null])],
+            'blank street line' => [array_merge($complete, ['street' => ['']])],
+            'no city' => [array_merge($complete, ['city' => null])],
+            'no country' => [array_merge($complete, ['country' => null])],
+            'no postcode' => [array_merge($complete, ['postcode' => null])],
+        ];
+    }
+
+    /**
+     * @return void
+     */
+    public function testSingleLineStreetLeavesLineTwoNull(): void
+    {
+        $cart = $this->createCart([
+            'firstname' => 'Ada',
+            'lastname' => 'Lovelace',
+            'street' => ['123 Main St'],
+            'city' => 'Austin',
+            'country' => 'US',
+            'postcode' => '78701',
+        ]);
+
+        $address = $this->cartToFulfillmentAddress->execute($cart);
+
+        $this->assertNotNull($address);
+        $this->assertSame('123 Main St', $address->getLineOne());
+        $this->assertNull($address->getLineTwo());
+        $this->assertNull($address->getState());
+    }
+
+    /**
+     * @return void
+     */
+    public function testTwoLineStreetIsSplitAcrossBothLines(): void
+    {
+        $cart = $this->createCart([
+            'firstname' => 'Ada',
+            'lastname' => 'Lovelace',
+            'street' => ['123 Main St', 'Apt 4'],
+            'city' => 'Austin',
+            'country' => 'US',
+            'postcode' => '78701',
+        ]);
+
+        $address = $this->cartToFulfillmentAddress->execute($cart);
+
+        $this->assertNotNull($address);
+        $this->assertSame('123 Main St', $address->getLineOne());
+        $this->assertSame('Apt 4', $address->getLineTwo());
+    }
+
+    /**
+     * A blank first line must not shift line two into line one's place.
+     *
+     * @return void
+     */
+    public function testBlankLeadingStreetLineIsDropped(): void
+    {
+        $cart = $this->createCart([
+            'firstname' => 'Ada',
+            'lastname' => 'Lovelace',
+            'street' => ['', 'Apt 4'],
+            'city' => 'Austin',
+            'country' => 'US',
+            'postcode' => '78701',
+        ]);
+
+        $address = $this->cartToFulfillmentAddress->execute($cart);
+
+        $this->assertNotNull($address);
+        $this->assertSame('Apt 4', $address->getLineOne());
+        $this->assertNull($address->getLineTwo());
+    }
+
+    /**
+     * @return void
+     */
+    public function testFullyPopulatedAddressIsMapped(): void
+    {
+        $cart = $this->createCart([
+            'firstname' => 'Ada',
+            'lastname' => 'Lovelace',
+            'street' => ['123 Main St', 'Apt 4'],
+            'city' => 'Austin',
+            'region' => 'Texas',
+            'country' => 'US',
+            'postcode' => '78701',
+        ]);
+
+        $address = $this->cartToFulfillmentAddress->execute($cart);
+
+        $this->assertNotNull($address);
+        $this->assertSame([
+            'name' => 'Ada Lovelace',
+            'line_one' => '123 Main St',
+            'line_two' => 'Apt 4',
+            'city' => 'Austin',
+            'state' => 'Texas',
+            'country' => 'US',
+            'postal_code' => '78701',
+        ], $address->toArray());
+    }
+
+    /**
+     * @param array<string, mixed> $addressData
+     * @return Quote&MockObject
+     */
+    private function createCart(array $addressData): Quote
+    {
+        $quoteAddress = $this->getMockBuilder(QuoteAddress::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'getFirstname',
+                'getLastname',
+                'getStreet',
+                'getCity',
+                'getRegion',
+                'getCountry',
+                'getPostcode',
+            ])
+            ->getMock();
+
+        // getStreet() returns [''] rather than [] when the quote has no street at all.
+        $street = $addressData['street'] ?? [''];
+
+        $quoteAddress->method('getFirstname')->willReturn($addressData['firstname'] ?? null);
+        $quoteAddress->method('getLastname')->willReturn($addressData['lastname'] ?? null);
+        $quoteAddress->method('getStreet')->willReturn($street === null ? [''] : $street);
+        $quoteAddress->method('getCity')->willReturn($addressData['city'] ?? null);
+        $quoteAddress->method('getRegion')->willReturn($addressData['region'] ?? null);
+        $quoteAddress->method('getCountry')->willReturn($addressData['country'] ?? null);
+        $quoteAddress->method('getPostcode')->willReturn($addressData['postcode'] ?? null);
+
+        $cart = $this->getMockBuilder(Quote::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getShippingAddress'])
+            ->getMock();
+        $cart->method('getShippingAddress')->willReturn($quoteAddress);
+
+        return $cart;
+    }
+}

--- a/Test/Unit/Model/Convert/ConvertPriceTest.php
+++ b/Test/Unit/Model/Convert/ConvertPriceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the Magebit_AgenticCommerce package.
+ *
+ * @copyright Copyright (c) 2025 Magebit, Ltd. (https://magebit.com/)
+ * @author    Magebit <info@magebit.com>
+ * @license   MIT
+ */
+
+declare(strict_types=1);
+
+namespace Magebit\AgenticCommerce\Test\Unit\Model\Convert;
+
+use Magebit\AgenticCommerce\Model\Convert\ConvertPrice;
+use PHPUnit\Framework\TestCase;
+
+class ConvertPriceTest extends TestCase
+{
+    /**
+     * @var ConvertPrice
+     */
+    private ConvertPrice $convertPrice;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->convertPrice = new ConvertPrice();
+    }
+
+    /**
+     * @dataProvider executeDataProvider
+     * @param float $amount
+     * @param string $currencyCode
+     * @param int $expected
+     * @return void
+     */
+    public function testExecute(float $amount, string $currencyCode, int $expected): void
+    {
+        $this->assertSame($expected, $this->convertPrice->execute($amount, $currencyCode));
+    }
+
+    /**
+     * @return array<string, array{0: float, 1: string, 2: int}>
+     */
+    public static function executeDataProvider(): array
+    {
+        return [
+            // Values the previous float-multiplication implementation truncated.
+            'usd 19.99 truncated to 1998' => [19.99, 'USD', 1999],
+            'usd 0.29 truncated to 28' => [0.29, 'USD', 29],
+            'usd 1.15 truncated to 114' => [1.15, 'USD', 115],
+            'usd 2.675 truncated to 267' => [2.675, 'USD', 268],
+            'usd 1000.005 truncated to 100000' => [1000.005, 'USD', 100001],
+
+            'usd zero' => [0.0, 'USD', 0],
+            'usd whole amount' => [10.0, 'USD', 1000],
+            'usd half rounds up' => [0.005, 'USD', 1],
+            'usd extra precision rounds up' => [123.456, 'USD', 12346],
+
+            // Discounts arrive as negative amounts; rounding is half away from zero.
+            'usd negative' => [-19.99, 'USD', -1999],
+            'usd negative sub-unit' => [-0.29, 'USD', -29],
+            'usd negative half rounds away from zero' => [-2.675, 'USD', -268],
+
+            // ISO 4217 exponent 0 — the minor unit is the major unit.
+            'jpy whole amount' => [1000.0, 'JPY', 1000],
+            'jpy rounds down' => [1000.4, 'JPY', 1000],
+            'jpy rounds up' => [1000.5, 'JPY', 1001],
+            'jpy negative' => [-1000.0, 'JPY', -1000],
+            'krw whole amount' => [50000.0, 'KRW', 50000],
+            'vnd whole amount' => [25000.0, 'VND', 25000],
+
+            // ISO 4217 exponent 3.
+            'kwd three decimals' => [1.005, 'KWD', 1005],
+            'kwd pads to three decimals' => [19.99, 'KWD', 19990],
+            'kwd sub-unit rounds up' => [0.0005, 'KWD', 1],
+            'kwd negative' => [-1.005, 'KWD', -1005],
+            'bhd three decimals' => [12.345, 'BHD', 12345],
+
+            'eur defaults to two' => [19.99, 'EUR', 1999],
+            'unknown code defaults to two' => [19.99, 'XYZ', 1999],
+            'lowercase currency code' => [19.99, 'usd', 1999],
+        ];
+    }
+}

--- a/Test/Unit/_fixtures/checkout_session.cancel.200.json
+++ b/Test/Unit/_fixtures/checkout_session.cancel.200.json
@@ -1,0 +1,89 @@
+{
+    "id": "checkout_session_placeholder_0001",
+    "line_items": [
+        {
+            "id": "1001",
+            "base_amount": 6400,
+            "subtotal": 6400,
+            "discount": 0,
+            "total": 6400,
+            "tax": 0,
+            "item": {
+                "id": "24-MB04",
+                "quantity": 2
+            }
+        }
+    ],
+    "fulfillment_address": {
+        "name": "Ada Lovelace",
+        "line_one": "123 Main St",
+        "line_two": null,
+        "city": "Austin",
+        "state": "Texas",
+        "country": "US",
+        "postal_code": "78701"
+    },
+    "totals": [
+        {
+            "type": "subtotal",
+            "display_text": "Subtotal",
+            "amount": 6400
+        },
+        {
+            "type": "shipping",
+            "display_text": "Shipping & Handling",
+            "amount": 0
+        },
+        {
+            "type": "tax",
+            "display_text": "Tax",
+            "amount": 0
+        },
+        {
+            "type": "grand_total",
+            "display_text": "Grand Total",
+            "amount": 6400
+        }
+    ],
+    "fulfillment_options": [
+        {
+            "type": "shipping",
+            "id": "flatrate_flatrate",
+            "title": "Flat Rate",
+            "subtotal": 1000,
+            "tax": 0,
+            "total": 1000
+        },
+        {
+            "type": "shipping",
+            "id": "tablerate_bestway",
+            "title": "Best Way",
+            "subtotal": 1500,
+            "tax": 0,
+            "total": 1500
+        }
+    ],
+    "payment_provider": {
+        "provider": "stripe",
+        "supported_payment_methods": [
+            "card"
+        ]
+    },
+    "currency": "USD",
+    "buyer": {
+        "first_name": "Ada",
+        "last_name": "Lovelace",
+        "email": "ada@example.com",
+        "phone_number": "+15555550123"
+    },
+    "links": [],
+    "messages": [
+        {
+            "type": "error",
+            "code": "cart_not_active",
+            "content_type": "plain",
+            "content": "Cart is not active. Please create a new checkout session"
+        }
+    ],
+    "status": "canceled"
+}

--- a/Test/Unit/_fixtures/checkout_session.complete.400.BROKEN.json
+++ b/Test/Unit/_fixtures/checkout_session.complete.400.BROKEN.json
@@ -1,0 +1,5 @@
+{
+    "type": "invalid_request",
+    "code": "invalid_request",
+    "message": "The requested Payment Method is not available."
+}

--- a/Test/Unit/_fixtures/checkout_session.create.200.json
+++ b/Test/Unit/_fixtures/checkout_session.create.200.json
@@ -1,0 +1,89 @@
+{
+    "id": "checkout_session_placeholder_0001",
+    "line_items": [
+        {
+            "id": "1001",
+            "base_amount": 6400,
+            "subtotal": 6400,
+            "discount": 0,
+            "total": 6400,
+            "tax": 0,
+            "item": {
+                "id": "24-MB04",
+                "quantity": 2
+            }
+        }
+    ],
+    "fulfillment_address": {
+        "name": "Ada Lovelace",
+        "line_one": "123 Main St",
+        "line_two": null,
+        "city": "Austin",
+        "state": "Texas",
+        "country": "US",
+        "postal_code": "78701"
+    },
+    "totals": [
+        {
+            "type": "subtotal",
+            "display_text": "Subtotal",
+            "amount": 6400
+        },
+        {
+            "type": "shipping",
+            "display_text": "Shipping & Handling",
+            "amount": 0
+        },
+        {
+            "type": "tax",
+            "display_text": "Tax",
+            "amount": 0
+        },
+        {
+            "type": "grand_total",
+            "display_text": "Grand Total",
+            "amount": 6400
+        }
+    ],
+    "fulfillment_options": [
+        {
+            "type": "shipping",
+            "id": "flatrate_flatrate",
+            "title": "Flat Rate",
+            "subtotal": 1000,
+            "tax": 0,
+            "total": 1000
+        },
+        {
+            "type": "shipping",
+            "id": "tablerate_bestway",
+            "title": "Best Way",
+            "subtotal": 1500,
+            "tax": 0,
+            "total": 1500
+        }
+    ],
+    "payment_provider": {
+        "provider": "stripe",
+        "supported_payment_methods": [
+            "card"
+        ]
+    },
+    "currency": "USD",
+    "buyer": {
+        "first_name": "Ada",
+        "last_name": "Lovelace",
+        "email": "ada@example.com",
+        "phone_number": "+15555550123"
+    },
+    "links": [],
+    "messages": [
+        {
+            "type": "error",
+            "code": "invalid",
+            "content_type": "plain",
+            "content": "Shipping method is required"
+        }
+    ],
+    "status": "not_ready_for_payment"
+}

--- a/Test/Unit/_fixtures/checkout_session.get.200.json
+++ b/Test/Unit/_fixtures/checkout_session.get.200.json
@@ -1,0 +1,89 @@
+{
+    "id": "checkout_session_placeholder_0001",
+    "line_items": [
+        {
+            "id": "1001",
+            "base_amount": 6400,
+            "subtotal": 6400,
+            "discount": 0,
+            "total": 6400,
+            "tax": 0,
+            "item": {
+                "id": "24-MB04",
+                "quantity": 2
+            }
+        }
+    ],
+    "fulfillment_address": {
+        "name": "Ada Lovelace",
+        "line_one": "123 Main St",
+        "line_two": null,
+        "city": "Austin",
+        "state": "Texas",
+        "country": "US",
+        "postal_code": "78701"
+    },
+    "totals": [
+        {
+            "type": "subtotal",
+            "display_text": "Subtotal",
+            "amount": 6400
+        },
+        {
+            "type": "shipping",
+            "display_text": "Shipping & Handling",
+            "amount": 0
+        },
+        {
+            "type": "tax",
+            "display_text": "Tax",
+            "amount": 0
+        },
+        {
+            "type": "grand_total",
+            "display_text": "Grand Total",
+            "amount": 6400
+        }
+    ],
+    "fulfillment_options": [
+        {
+            "type": "shipping",
+            "id": "flatrate_flatrate",
+            "title": "Flat Rate",
+            "subtotal": 1000,
+            "tax": 0,
+            "total": 1000
+        },
+        {
+            "type": "shipping",
+            "id": "tablerate_bestway",
+            "title": "Best Way",
+            "subtotal": 1500,
+            "tax": 0,
+            "total": 1500
+        }
+    ],
+    "payment_provider": {
+        "provider": "stripe",
+        "supported_payment_methods": [
+            "card"
+        ]
+    },
+    "currency": "USD",
+    "buyer": {
+        "first_name": "Ada",
+        "last_name": "Lovelace",
+        "email": "ada@example.com",
+        "phone_number": "+15555550123"
+    },
+    "links": [],
+    "messages": [
+        {
+            "type": "error",
+            "code": "invalid",
+            "content_type": "plain",
+            "content": "Shipping method is required"
+        }
+    ],
+    "status": "not_ready_for_payment"
+}

--- a/Test/Unit/_fixtures/checkout_session.update.200.json
+++ b/Test/Unit/_fixtures/checkout_session.update.200.json
@@ -1,0 +1,89 @@
+{
+    "id": "checkout_session_placeholder_0001",
+    "line_items": [
+        {
+            "id": "1001",
+            "base_amount": 9600,
+            "subtotal": 9600,
+            "discount": 0,
+            "total": 9600,
+            "tax": 0,
+            "item": {
+                "id": "24-MB04",
+                "quantity": 3
+            }
+        }
+    ],
+    "fulfillment_address": {
+        "name": "Ada Lovelace",
+        "line_one": "123 Main St",
+        "line_two": null,
+        "city": "Austin",
+        "state": "Texas",
+        "country": "US",
+        "postal_code": "78701"
+    },
+    "totals": [
+        {
+            "type": "subtotal",
+            "display_text": "Subtotal",
+            "amount": 9600
+        },
+        {
+            "type": "shipping",
+            "display_text": "Shipping & Handling",
+            "amount": 0
+        },
+        {
+            "type": "tax",
+            "display_text": "Tax",
+            "amount": 0
+        },
+        {
+            "type": "grand_total",
+            "display_text": "Grand Total",
+            "amount": 9600
+        }
+    ],
+    "fulfillment_options": [
+        {
+            "type": "shipping",
+            "id": "flatrate_flatrate",
+            "title": "Flat Rate",
+            "subtotal": 1500,
+            "tax": 0,
+            "total": 1500
+        },
+        {
+            "type": "shipping",
+            "id": "tablerate_bestway",
+            "title": "Best Way",
+            "subtotal": 1500,
+            "tax": 0,
+            "total": 1500
+        }
+    ],
+    "payment_provider": {
+        "provider": "stripe",
+        "supported_payment_methods": [
+            "card"
+        ]
+    },
+    "currency": "USD",
+    "buyer": {
+        "first_name": "Ada",
+        "last_name": "Lovelace",
+        "email": "ada@example.com",
+        "phone_number": "+15555550123"
+    },
+    "links": [],
+    "messages": [
+        {
+            "type": "error",
+            "code": "invalid",
+            "content_type": "plain",
+            "content": "Shipping method is required"
+        }
+    ],
+    "status": "not_ready_for_payment"
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,1033 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Parameter \$products of method Magebit\\AgenticCommerce\\Api\\ProductFeedWriterInterface\:\:write\(\) has invalid type Magebit\\AgenticCommerce\\Api\\FeedProductInterface\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Api/ProductFeedWriterInterface.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Block\\Adminhtml\\Form\\Field\\AcStatusColumn\:\:setInputName\(\) should return \$this\(Magebit\\AgenticCommerce\\Block\\Adminhtml\\Form\\Field\\AcStatusColumn\) but returns Magebit\\AgenticCommerce\\Block\\Adminhtml\\Form\\Field\\AcStatusColumn\.$#'
+			identifier: return.type
+			count: 1
+			path: Block/Adminhtml/Form/Field/AcStatusColumn.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Block\\Adminhtml\\Form\\Field\\LinkTypeColumn\:\:getSourceOptions\(\) should return array\<int, array\{label\: string, value\: int\}\> but returns array\{array\{label\: ''Terms of Use'', value\: ''terms_of_use''\}, array\{label\: ''Privacy Policy'', value\: ''privacy_policy''\}, array\{label\: ''Seller Shop Policies'', value\: ''seller_shop_policies''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: Block/Adminhtml/Form/Field/LinkTypeColumn.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Block\\Adminhtml\\Form\\Field\\MagentoOrderStatusColumn\:\:setInputName\(\) should return \$this\(Magebit\\AgenticCommerce\\Block\\Adminhtml\\Form\\Field\\MagentoOrderStatusColumn\) but returns Magebit\\AgenticCommerce\\Block\\Adminhtml\\Form\\Field\\MagentoOrderStatusColumn\.$#'
+			identifier: return.type
+			count: 1
+			path: Block/Adminhtml/Form/Field/MagentoOrderStatusColumn.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Block\\Adminhtml\\Form\\Field\\OrderStatusMap\:\:getAcStatusRenderer\(\) has Magento\\Framework\\Exception\\LocalizedException in PHPDoc @throws tag but it''s not thrown\.$#'
+			identifier: throws.unusedType
+			count: 1
+			path: Block/Adminhtml/Form/Field/OrderStatusMap.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Block\\Adminhtml\\Form\\Field\\OrderStatusMap\:\:getMagentoStatusRenderer\(\) has Magento\\Framework\\Exception\\LocalizedException in PHPDoc @throws tag but it''s not thrown\.$#'
+			identifier: throws.unusedType
+			count: 1
+			path: Block/Adminhtml/Form/Field/OrderStatusMap.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 2
+			path: Block/Adminhtml/Form/Field/OrderStatusMap.php
+
+		-
+			message: '#^Parameter \#1 \$feedFilePath of method Magebit\\AgenticCommerce\\Model\\Export\\ProductFeed\:\:setFeedFilePath\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Console/Command/ExportFeed.php
+
+		-
+			message: '#^Parameter \#1 \$storeId of method Magebit\\AgenticCommerce\\Model\\Export\\ProductFeed\:\:setStoreId\(\) expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Console/Command/ExportFeed.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 2
+			path: Model/Config.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Config\\ProductFeedMapping\:\:getMappingsForType\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Model/Config/ProductFeedMapping.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Config\\ProductFeedMapping\:\:getMappingsForTypes\(\) has parameter \$types with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Model/Config/ProductFeedMapping.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Config\\ProductFeedMapping\:\:getMappingsForTypes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Model/Config/ProductFeedMapping.php
+
+		-
+			message: '#^Parameter \#2 \.\.\.\$arrays of function array_merge expects array, array\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Config/ProductFeedMapping.php
+
+		-
+			message: '#^Call to an undefined method DOMNode\:\:getAttribute\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Model/Config/ProductFeedMapping/Converter.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Config\\ProductFeedMapping\\Converter\:\:convert\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Model/Config/ProductFeedMapping/Converter.php
+
+		-
+			message: '#^Cannot access offset ''value'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Model/Config/ProductFeedMapping/Data.php
+
+		-
+			message: '#^Cannot access offset ''xsi\:type'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: Model/Config/ProductFeedMapping/Data.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Config\\ProductFeedMapping\\Data\:\:__construct\(\) has parameter \$cacheTags with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Model/Config/ProductFeedMapping/Data.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Config\\ProductFeedMapping\\Data\:\:getMappingsForType\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Model/Config/ProductFeedMapping/Data.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$id$#'
+			identifier: parameter.notFound
+			count: 1
+			path: Model/Config/ProductFeedMapping/Data.php
+
+		-
+			message: '#^Parameter \#1 \$data of method Magento\\Framework\\Data\\Argument\\InterpreterInterface\:\:evaluate\(\) expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Config/ProductFeedMapping/Data.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_map expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Config/ProductFeedMapping/Data.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Config\\ProductFeedMapping\\DataInterface\:\:getMappingsForType\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Model/Config/ProductFeedMapping/DataInterface.php
+
+		-
+			message: '#^Cannot call method getData\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: Model/Config/Source/GtinSource.php
+
+		-
+			message: '#^Parameter \#1 \$quantity of method Magebit\\AgenticCommerce\\Api\\Data\\ItemInterface\:\:setQuantity\(\) expects int, float\|int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Convert/CartItemToLineItem.php
+
+		-
+			message: '#^PHPDoc tag @var with type Magebit\\AgenticCommerce\\Model\\Data\\Order is not subtype of native type Magento\\Sales\\Api\\Data\\OrderInterface\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: Model/Convert/OrderToOrderCreatedUpdatedWebhook.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getAdditionalImageLink\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getAgeGroup\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getAgeRestriction\(\) should return int\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getApplicableTaxesFees\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getAvailability\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getAvailabilityDate\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getBaseMeasure\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getBrand\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getColor\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getCondition\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getCustomVariant1Category\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getCustomVariant1Option\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getCustomVariant2Category\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getCustomVariant2Option\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getCustomVariant3Category\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getCustomVariant3Option\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getDeliveryEstimate\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getDescription\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getDimensions\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getExpirationDate\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getGender\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getGeoAvailability\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getGeoPrice\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getGtin\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getHeight\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getId\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getImageLink\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getInventoryQuantity\(\) should return int but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getItemGroupId\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getItemGroupTitle\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getLength\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getLink\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getMaterial\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getModel3DLink\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getMpn\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getOfferId\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getPickupMethod\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getPickupSla\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getPopularityScore\(\) should return float\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getPrice\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getPricingTrend\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getProductCategory\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getProductReviewCount\(\) should return int\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getProductReviewRating\(\) should return float\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getQAndA\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getRawReviewData\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getRelatedProductId\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getRelationshipType\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getReturnPolicy\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getReturnRate\(\) should return float\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getReturnWindow\(\) should return int but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getSalePrice\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getSalePriceEffectiveDate\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getSellerName\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getSellerPrivacyPolicy\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getSellerTos\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getSellerUrl\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getShipping\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getSize\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getSizeSystem\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getStoreReviewCount\(\) should return int\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getStoreReviewRating\(\) should return float\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getTitle\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getUnitPricingMeasure\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getVideoLink\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getWarning\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getWarningUrl\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getWeight\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Feed\\Product\:\:getWidth\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Feed/Product.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\FulfillmentOptionShipping\:\:getCarrier\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/FulfillmentOptionShipping.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\FulfillmentOptionShipping\:\:getEarliestDeliveryTime\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/FulfillmentOptionShipping.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\FulfillmentOptionShipping\:\:getLatestDeliveryTime\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/FulfillmentOptionShipping.php
+
+		-
+			message: '#^Call to an undefined static method Magebit\\AgenticCommerce\\Model\\Data\\Item\:\:from\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: Model/Data/LineItem.php
+
+		-
+			message: '#^Cannot cast mixed to int\.$#'
+			identifier: cast.int
+			count: 5
+			path: Model/Data/LineItem.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 1
+			path: Model/Data/LineItem.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 2
+			path: Model/Data/PaymentData.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\PaymentData\:\:__construct\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Model/Data/PaymentData.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{buyer\: Symfony\\Component\\Validator\\Constraints\\Optional, payment_data\: Symfony\\Component\\Validator\\Constraints\\Required\}, allowExtraFields\: true, allowMissingFields\: false\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/CompleteCheckoutSessionRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{first_name\: Symfony\\Component\\Validator\\Constraints\\Required, last_name\: Symfony\\Component\\Validator\\Constraints\\Required, email\: Symfony\\Component\\Validator\\Constraints\\Required, phone_number\: Symfony\\Component\\Validator\\Constraints\\Optional\}, allowExtraFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/CompleteCheckoutSessionRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{name\: Symfony\\Component\\Validator\\Constraints\\Required, line_one\: Symfony\\Component\\Validator\\Constraints\\Required, line_two\: Symfony\\Component\\Validator\\Constraints\\Optional, city\: Symfony\\Component\\Validator\\Constraints\\Required, state\: Symfony\\Component\\Validator\\Constraints\\Optional, country\: Symfony\\Component\\Validator\\Constraints\\Required, postal_code\: Symfony\\Component\\Validator\\Constraints\\Required\}, allowExtraFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/CompleteCheckoutSessionRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{token\: Symfony\\Component\\Validator\\Constraints\\Required, provider\: Symfony\\Component\\Validator\\Constraints\\Required, billing_address\: Symfony\\Component\\Validator\\Constraints\\Optional\}, allowExtraFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/CompleteCheckoutSessionRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{buyer\: Symfony\\Component\\Validator\\Constraints\\Optional, items\: Symfony\\Component\\Validator\\Constraints\\Required, fulfillment_address\: Symfony\\Component\\Validator\\Constraints\\Optional\}, allowExtraFields\: true, allowMissingFields\: false\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/CreateCheckoutSessionRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{first_name\: Symfony\\Component\\Validator\\Constraints\\Required, last_name\: Symfony\\Component\\Validator\\Constraints\\Required, email\: Symfony\\Component\\Validator\\Constraints\\Required, phone_number\: Symfony\\Component\\Validator\\Constraints\\Optional\}, allowExtraFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/CreateCheckoutSessionRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{id\: Symfony\\Component\\Validator\\Constraints\\Required, quantity\: Symfony\\Component\\Validator\\Constraints\\Required\}, allowExtraFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/CreateCheckoutSessionRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{name\: Symfony\\Component\\Validator\\Constraints\\Required, line_one\: Symfony\\Component\\Validator\\Constraints\\Required, line_two\: Symfony\\Component\\Validator\\Constraints\\Optional, city\: Symfony\\Component\\Validator\\Constraints\\Required, state\: Symfony\\Component\\Validator\\Constraints\\Optional, country\: Symfony\\Component\\Validator\\Constraints\\Required, postal_code\: Symfony\\Component\\Validator\\Constraints\\Required\}, allowExtraFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/CreateCheckoutSessionRequest.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Request\\DelegatePaymentRequest\:\:getAllowance\(\) should return Magebit\\AgenticCommerce\\Api\\Data\\AllowanceInterface but returns Magebit\\AgenticCommerce\\Api\\Data\\AllowanceInterface\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Request/DelegatePaymentRequest.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Request\\DelegatePaymentRequest\:\:getPaymentMethod\(\) should return Magebit\\AgenticCommerce\\Api\\Data\\PaymentMethodInterface but returns Magebit\\AgenticCommerce\\Api\\Data\\PaymentMethodInterface\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Request/DelegatePaymentRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{name\: Symfony\\Component\\Validator\\Constraints\\Required, line_one\: Symfony\\Component\\Validator\\Constraints\\Required, line_two\: Symfony\\Component\\Validator\\Constraints\\Optional, city\: Symfony\\Component\\Validator\\Constraints\\Required, state\: Symfony\\Component\\Validator\\Constraints\\Optional, country\: Symfony\\Component\\Validator\\Constraints\\Required, postal_code\: Symfony\\Component\\Validator\\Constraints\\Required\}, allowExtraFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/DelegatePaymentRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{payment_method\: Symfony\\Component\\Validator\\Constraints\\Required, allowance\: Symfony\\Component\\Validator\\Constraints\\Required, billing_address\: Symfony\\Component\\Validator\\Constraints\\Optional, risk_signals\: Symfony\\Component\\Validator\\Constraints\\Required, metadata\: Symfony\\Component\\Validator\\Constraints\\Required\}, allowExtraFields\: true, allowMissingFields\: false\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/DelegatePaymentRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{reason\: Symfony\\Component\\Validator\\Constraints\\Required, max_amount\: Symfony\\Component\\Validator\\Constraints\\Required, currency\: Symfony\\Component\\Validator\\Constraints\\Required, checkout_session_id\: Symfony\\Component\\Validator\\Constraints\\Required, merchant_id\: Symfony\\Component\\Validator\\Constraints\\Required, expires_at\: Symfony\\Component\\Validator\\Constraints\\Required\}, allowExtraFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/DelegatePaymentRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{type\: Symfony\\Component\\Validator\\Constraints\\Required, card_number_type\: Symfony\\Component\\Validator\\Constraints\\Required, number\: Symfony\\Component\\Validator\\Constraints\\Required, display_card_funding_type\: Symfony\\Component\\Validator\\Constraints\\Required, metadata\: Symfony\\Component\\Validator\\Constraints\\Required, exp_month\: Symfony\\Component\\Validator\\Constraints\\Optional, exp_year\: Symfony\\Component\\Validator\\Constraints\\Optional, name\: Symfony\\Component\\Validator\\Constraints\\Optional, \.\.\.\}, allowExtraFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/DelegatePaymentRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{type\: Symfony\\Component\\Validator\\Constraints\\Required, score\: Symfony\\Component\\Validator\\Constraints\\Required, action\: Symfony\\Component\\Validator\\Constraints\\Required\}, allowExtraFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/DelegatePaymentRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{buyer\: Symfony\\Component\\Validator\\Constraints\\Optional, items\: Symfony\\Component\\Validator\\Constraints\\Optional, fulfillment_address\: Symfony\\Component\\Validator\\Constraints\\Optional, fulfillment_option_id\: Symfony\\Component\\Validator\\Constraints\\Optional\}, allowExtraFields\: true, allowMissingFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/UpdateCheckoutSessionRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{first_name\: Symfony\\Component\\Validator\\Constraints\\Required, last_name\: Symfony\\Component\\Validator\\Constraints\\Required, email\: Symfony\\Component\\Validator\\Constraints\\Required, phone_number\: Symfony\\Component\\Validator\\Constraints\\Optional\}, allowExtraFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/UpdateCheckoutSessionRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{id\: Symfony\\Component\\Validator\\Constraints\\Required, quantity\: Symfony\\Component\\Validator\\Constraints\\Required\}, allowExtraFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/UpdateCheckoutSessionRequest.php
+
+		-
+			message: '#^Parameter \#1 \$fields of class Symfony\\Component\\Validator\\Constraints\\Collection constructor expects array\<string, list\<Symfony\\Component\\Validator\\Constraint\>\|Symfony\\Component\\Validator\\Constraint\>\|null, array\{fields\: array\{name\: Symfony\\Component\\Validator\\Constraints\\Required, line_one\: Symfony\\Component\\Validator\\Constraints\\Required, line_two\: Symfony\\Component\\Validator\\Constraints\\Optional, city\: Symfony\\Component\\Validator\\Constraints\\Required, state\: Symfony\\Component\\Validator\\Constraints\\Optional, country\: Symfony\\Component\\Validator\\Constraints\\Required, postal_code\: Symfony\\Component\\Validator\\Constraints\\Required\}, allowExtraFields\: true\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Data/Request/UpdateCheckoutSessionRequest.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 3
+			path: Model/Data/Response/CheckoutSessionResponse.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Response\\CheckoutSessionResponse\:\:getBuyer\(\) should return Magebit\\AgenticCommerce\\Api\\Data\\BuyerInterface\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Response/CheckoutSessionResponse.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Response\\CheckoutSessionResponse\:\:getFulfillmentAddress\(\) should return Magebit\\AgenticCommerce\\Api\\Data\\AddressInterface\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Response/CheckoutSessionResponse.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Response\\CheckoutSessionResponse\:\:getFulfillmentOptionId\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Response/CheckoutSessionResponse.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Response\\CheckoutSessionResponse\:\:getFulfillmentOptions\(\) should return array\<Magebit\\AgenticCommerce\\Api\\Data\\FulfillmentOptionInterface\> but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Response/CheckoutSessionResponse.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Response\\CheckoutSessionResponse\:\:getLineItems\(\) should return array\<Magebit\\AgenticCommerce\\Api\\Data\\LineItemInterface\> but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Response/CheckoutSessionResponse.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Response\\CheckoutSessionResponse\:\:getLinks\(\) should return array\<Magebit\\AgenticCommerce\\Api\\Data\\LinkInterface\> but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Response/CheckoutSessionResponse.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Response\\CheckoutSessionResponse\:\:getMessages\(\) should return array\<Magebit\\AgenticCommerce\\Api\\Data\\MessageInterface\> but returns array\<mixed\>\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Response/CheckoutSessionResponse.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Response\\CheckoutSessionResponse\:\:getPaymentProvider\(\) should return Magebit\\AgenticCommerce\\Api\\Data\\PaymentProviderInterface\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Response/CheckoutSessionResponse.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Response\\CheckoutSessionResponse\:\:getTotals\(\) should return array\<Magebit\\AgenticCommerce\\Api\\Data\\TotalInterface\> but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Response/CheckoutSessionResponse.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Data\\Response\\CheckoutSessionWithOrderResponse\:\:getOrder\(\) should return Magebit\\AgenticCommerce\\Api\\Data\\OrderInterface but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Data/Response/CheckoutSessionWithOrderResponse.php
+
+		-
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: Model/Export/ProductFeed.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Export\\ProductFeed\:\:export\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Model/Export/ProductFeed.php
+
+		-
+			message: '#^Parameter \#1 \$feedFilePath of method Magebit\\AgenticCommerce\\Api\\ProductFeedWriterInterface\:\:setFeedFilePath\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Export/ProductFeed.php
+
+		-
+			message: '#^Parameter \#1 \$product of method Magebit\\AgenticCommerce\\Model\\Export\\ProductFeed\:\:mapProduct\(\) expects Magento\\Catalog\\Api\\Data\\ProductInterface, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Export/ProductFeed.php
+
+		-
+			message: '#^Parameter \#1 \$products of method Magebit\\AgenticCommerce\\Api\\ProductFeedWriterInterface\:\:write\(\) expects array\<Magebit\\AgenticCommerce\\Api\\FeedProductInterface\>, array\<Magebit\\AgenticCommerce\\Api\\Data\\FeedProductInterface\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Export/ProductFeed.php
+
+		-
+			message: '#^Parameter \#2 \$condition of method Magento\\Catalog\\Model\\ResourceModel\\Product\\Collection\:\:addAttributeToFilter\(\) expects array\|null, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Export/ProductFeed.php
+
+		-
+			message: '#^Parameter \#2 \$page of method Magebit\\AgenticCommerce\\Api\\ProductFeedWriterInterface\:\:write\(\) expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Export/ProductFeed.php
+
+		-
+			message: '#^Variable \$data might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: Model/Export/ProductFeed.php
+
+		-
+			message: '#^Call to method getData\(\) on an unknown class Magebit\\AgenticCommerce\\Model\\Export\\Writer\\FeedProductInterface\.$#'
+			identifier: class.notFound
+			count: 2
+			path: Model/Export/Writer/CsvWriter.php
+
+		-
+			message: '#^Parameter \$products of method Magebit\\AgenticCommerce\\Model\\Export\\Writer\\CsvWriter\:\:write\(\) has invalid type Magebit\\AgenticCommerce\\Model\\Export\\Writer\\FeedProductInterface\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Model/Export/Writer/CsvWriter.php
+
+		-
+			message: '#^Cannot cast mixed to int\.$#'
+			identifier: cast.int
+			count: 1
+			path: Model/Idempotency/Model.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 5
+			path: Model/Idempotency/Model.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Mapping\\AbstractMapper\:\:formatValue\(\) has parameter \$mapping with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Model/Mapping/AbstractMapper.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Mapping\\AbstractMapper\:\:getAttributeValue\(\) has parameter \$mapping with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Model/Mapping/AbstractMapper.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Mapping\\AbstractMapper\:\:mapAttribute\(\) has parameter \$mapping with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: Model/Mapping/AbstractMapper.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$productTypeMappers$#'
+			identifier: parameter.notFound
+			count: 1
+			path: Model/Mapping/AbstractMapper.php
+
+		-
+			message: '#^Call to an undefined method Magento\\Catalog\\Api\\Data\\ProductInterface\:\:getData\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Model/Mapping/ConfigurableProductMapper.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Mapping\\ConfigurableProductMapper\:\:addVariantAttributes\(\) with return type void returns array\<string, mixed\> but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: Model/Mapping/ConfigurableProductMapper.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Mapping\\ConfigurableProductMapper\:\:getChildProducts\(\) should return array\<Magento\\Catalog\\Model\\Product\> but returns array\<Magento\\Catalog\\Api\\Data\\ProductInterface\>\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Mapping/ConfigurableProductMapper.php
+
+		-
+			message: '#^Parameter \#2 \.\.\.\$arrays of function array_merge expects array, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Model/Mapping/ConfigurableProductMapper.php
+
+		-
+			message: '#^Result of method Magebit\\AgenticCommerce\\Model\\Mapping\\ConfigurableProductMapper\:\:addVariantAttributes\(\) \(void\) is used\.$#'
+			identifier: method.void
+			count: 1
+			path: Model/Mapping/ConfigurableProductMapper.php
+
+		-
+			message: '#^Variable \$data might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: Model/Mapping/ConfigurableProductMapper.php
+
+		-
+			message: '#^Call to method getData\(\) on an unknown class Magebit\\AgenticCommerce\\Model\\Mapping\\Formatter\\Product\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Model/Mapping/Formatter/EnableSearch.php
+
+		-
+			message: '#^PHPDoc tag @var for variable \$product contains unknown class Magebit\\AgenticCommerce\\Model\\Mapping\\Formatter\\Product\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Model/Mapping/Formatter/EnableSearch.php
+
+		-
+			message: '#^PHPDoc tag @var with type Magebit\\AgenticCommerce\\Model\\Mapping\\Formatter\\Product is not subtype of native type Magento\\Catalog\\Api\\Data\\ProductInterface\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: Model/Mapping/Formatter/EnableSearch.php
+
+		-
+			message: '#^Call to method getStoreId\(\) on an unknown class Magebit\\AgenticCommerce\\Model\\Mapping\\Formatter\\Product\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Model/Mapping/Formatter/Price.php
+
+		-
+			message: '#^Cannot cast mixed to float\.$#'
+			identifier: cast.double
+			count: 1
+			path: Model/Mapping/Formatter/Price.php
+
+		-
+			message: '#^PHPDoc tag @var with type Magebit\\AgenticCommerce\\Model\\Mapping\\Formatter\\Product is not subtype of native type Magento\\Catalog\\Api\\Data\\ProductInterface\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: Model/Mapping/Formatter/Price.php
+
+		-
+			message: '#^Parameter \#1 \$datetime of function strtotime expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: Model/Mapping/Source/SalePriceEffectiveDate.php
+
+		-
+			message: '#^Property Magebit\\AgenticCommerce\\Model\\Mapping\\Source\\SalePriceEffectiveDate\:\:\$imageUrlBuilder is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: Model/Mapping/Source/SalePriceEffectiveDate.php
+
+		-
+			message: '#^Call to an undefined method Magento\\Catalog\\Api\\Data\\ProductInterface\:\:getData\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Model/Mapping/Source/SellerPrivacyPolicy.php
+
+		-
+			message: '#^Call to an undefined method Magento\\Catalog\\Api\\Data\\ProductInterface\:\:getData\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Model/Mapping/Source/SellerTos.php
+
+		-
+			message: '#^Method Magebit\\AgenticCommerce\\Model\\Product\\Attribute\\Source\\EnableSearch\:\:getAllOptions\(\) should return array\<array\{value\: string, label\: string\}\> but returns array\{array\{value\: ''visibility'', label\: Magento\\Framework\\Phrase\}, array\{value\: ''enabled'', label\: Magento\\Framework\\Phrase\}, array\{value\: ''disabled'', label\: Magento\\Framework\\Phrase\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: Model/Product/Attribute/Source/EnableSearch.php
+
+		-
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
+			count: 1
+			path: Service/CheckoutSessionService.php
+
+		-
+			message: '#^Parameter \#1 \$region of method Magento\\Quote\\Api\\Data\\AddressInterface\:\:setRegion\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Service/CheckoutSessionService.php
+
+		-
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
+			count: 1
+			path: Service/CheckoutSessionService.php
+
+		-
+			message: '#^PHPDoc tag @var with type Magebit\\AgenticCommerce\\Model\\Data\\Webhook\\EventData is not subtype of native type Magebit\\AgenticCommerce\\Api\\Data\\Webhook\\WebhookEventInterface\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: Service/WebhookService.php
+
+		-
+			message: '#^Return type \(void\) of method Magebit\\AgenticCommerce\\Setup\\Patch\\Data\\AddProductAttributes\:\:apply\(\) should be compatible with return type \(\$this\(Magento\\Framework\\Setup\\Patch\\PatchInterface\)\) of method Magento\\Framework\\Setup\\Patch\\PatchInterface\:\:apply\(\)$#'
+			identifier: method.childReturnType
+			count: 2
+			path: Setup/Patch/Data/AddProductAttributes.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 9
+    excludePaths:
+        - Test/*


### PR DESCRIPTION
Adds the test infrastructure this module had none of, then fixes what it found.

## Money conversion was wrong twice over

```php
return (int) ($price * 100);
```

**Float truncation.** `(int)` truncates toward zero and `19.99 * 100` is `1998.9999999999998`, so
`19.99` became **1998**. Verified: `0.29 → 28`, `1.15 → 114`, `2.675 → 267`, `1000.005 → 100000`.

**Hardcoded ×100.** ACP amounts are ISO 4217 minor units. JPY and KRW have exponent 0, KWD and BHD
have 3 — so a ¥1000 order reported 100000 minor units, **100× the real amount**.

Replaced with decimal-string conversion (`number_format` at the currency's exponent, separator
stripped — no float arithmetic, locale-independent) plus an exponent table. `execute()` now takes
a currency code, resolved at each call site from the same source the module already uses for the
currency it *reports*, so the exponent cannot disagree with the declared currency. The creditmemo
observer uses the order currency, since `getGrandTotal()` is denominated in it.

The failing test was written first: **24 of 26 cases red** before the fix, all green after.

`declare(strict_types=1)` was also missing from `ConvertPrice` and has been added.

## `fulfillment_address` null-safety

`CartToFulfillmentAddress::execute()` was hardened for partial addresses, which are legitimate —
a shipping estimate can carry country and postcode with no region.

The real trap was `getStreet()`. `Quote\Address::getStreet()` does `explode("\n", getStreetFull())`,
which returns `['']` — a **truthy** array — when street is unset, so the previous
`!$shippingAddress->getStreet()` guard passed it through and emitted `"line_one": ""`. Street lines
are now trimmed, blanks filtered and re-indexed, so `['', 'Apt 4']` maps to `line_one: "Apt 4"`
rather than an empty string.

Every field is normalised through a single helper, so a whitespace-only value counts as missing and
a non-scalar cannot reach a `string` setter — relevant for `getRegion()`, which returns raw
`getData('region')` and can be an array on a half-resolved region.

The address is built only when the quote actually has a usable one, and the response field is left
**unset** otherwise — `fulfillment_address` is optional in ACP, and `setFulfillmentAddress(null)`
would still emit `"fulfillment_address": null` through `DataObject::toArray()`.

## Tooling

`phpstan.neon` + baseline (190 errors, real and tracked — CI now fails on *new* errors only), and
golden fixtures for checkout create/get/update/cancel/complete under `Test/Unit/_fixtures/`.

Fixtures are **portable**: every environment-derived value is normalised — origin, static deploy
version, media cache hash, session and item ids, timestamps, nonces. No fixture contains a
developer's local hostname.

No per-module `phpunit.xml.dist` or bootstrap: tests run against Magento's own config with a path
argument, matching the convention in `magebitcom/magento2-mcp-module`.

## Verification

`phpcs` clean, `phpstan` level 9 clean against the baseline, **47 tests / 87 assertions** green.
`GET`, update and `cancel` all return 200; create returns 200 with `fulfillment_address` correctly
absent on an addressless session.

## Note for anyone deploying this

`symfony/validator` is declared in this module's `composer.json` but is not pulled in when the
module is installed under `app/code` rather than via Composer. Without it every request 500s in
`RequestValidationService`, whatever the `API-Version` header says.

## Known, not addressed here

- **`POST /{id}/complete` returns 400** — `StripePaymentsHandler` sets
  `$payment->setMethod('stripe_payments')`, but no Stripe package is installed, so Magento rejects
  the method. Environment/dependency gap, recorded in a `BROKEN` fixture.
- **`"regionId" is required` on a US address.** `addDataToQuoteAddress()` passes the region *name*
  to `setRegion()` and never resolves `region_id`, so a US address never reaches
  `ready_for_payment`. Real defect; needs region resolution.
- **`CheckoutSessionService:314`** feeds a nullable `getCurrency()?->getStoreCurrencyCode()` into
  `setCurrency(string)`. Unreachable in practice, but the available fixes are inventing a fallback
  currency — which would put a wrong currency into an ACP response — or throwing. Worth a
  deliberate decision rather than a drive-by.
- `CartToTotals` emits raw Magento total codes rather than the ACP vocabulary defined in
  `Api/Data/TotalInterface.php`, whose constants have zero references outside the interface.
